### PR TITLE
Update pkcs7 library, use crypto.Signer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/digitorus/timestamp
 
 go 1.16
 
-require github.com/digitorus/pkcs7 v0.0.0-20220704143225-a9c8106cbfc6
+require github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/digitorus/pkcs7 v0.0.0-20200320092839-808436b6f6d1 h1:V1cgDSp4Kq4eMCfazhWyqi2Js7BijkgPnp4Yej9CD9I=
-github.com/digitorus/pkcs7 v0.0.0-20200320092839-808436b6f6d1/go.mod h1:p2IZ9yq2kEKGFr3rfpYxaaOzB0VdLbF8VkZReEIpJmU=
-github.com/digitorus/pkcs7 v0.0.0-20220704143225-a9c8106cbfc6 h1:b98clxJQS08ohZb7PuAqYJw6WvIJGcAWoUVPgOHwNw0=
-github.com/digitorus/pkcs7 v0.0.0-20220704143225-a9c8106cbfc6/go.mod h1:ajT9Iifwrck892Z07+wD+dRRv9ULmlmPG0A+OHSrDuQ=
+github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4 h1:MxNIia2F3bgFyNsOZy9UbNlpKAxbtCudkVmlJBNuvmg=
+github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=

--- a/timestamp.go
+++ b/timestamp.go
@@ -591,7 +591,7 @@ func (t *Timestamp) populateSigningCertificateV2Ext(certificate *x509.Certificat
 	return signingCertV2Bytes, nil
 }
 
-func (t *Timestamp) generateSignedData(tstInfo []byte, privateKey crypto.PrivateKey, certificate *x509.Certificate) ([]byte, error) {
+func (t *Timestamp) generateSignedData(tstInfo []byte, signer crypto.Signer, certificate *x509.Certificate) ([]byte, error) {
 	signedData, err := pkcs7.NewSignedData(tstInfo)
 	if err != nil {
 		return nil, err
@@ -616,7 +616,7 @@ func (t *Timestamp) generateSignedData(tstInfo []byte, privateKey crypto.Private
 		signerInfoConfig.SkipCertificates = true
 	}
 
-	err = signedData.AddSigner(certificate, privateKey, signerInfoConfig)
+	err = signedData.AddSigner(certificate, signer, signerInfoConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes no changes to the public interface, just to a private function.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>