### PR TITLE
Use `GetDigestOIDForSignatureAlgorithm` to set the digest algorithm OID

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Get dependencies
         run: go get -v -t -d ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.46
+          version: v1.53
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,0 @@
-coverage:
-  status:
-    project: off
-    patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/digitorus/timestamp
 go 1.16
 
 require github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4
+
+replace github.com/digitorus/pkcs7 => github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/digitorus/timestamp
 
 go 1.16
 
-require github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4
-
-replace github.com/digitorus/pkcs7 => github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb
+require github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb h1:+SUAUbIpNMX0UBNbBLjBBiShLn+WSqoVGi+8N6jMLr8=
-github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
+github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49 h1:h+XMRXf+WLY0h/3itqE8OT3TgjCMHK4nq2FNGi0au2c=
+github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4 h1:MxNIia2F3bgFyNsOZy9UbNlpKAxbtCudkVmlJBNuvmg=
-github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
+github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb h1:+SUAUbIpNMX0UBNbBLjBBiShLn+WSqoVGi+8N6jMLr8=
+github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=

--- a/rfc3161_struct.go
+++ b/rfc3161_struct.go
@@ -45,7 +45,7 @@ func (s pkiStatusInfo) FailureInfo() FailureInfo {
 		}
 	}
 
-	return UnkownFailureInfo
+	return UnknownFailureInfo
 }
 
 // eContent within SignedData is TSTInfo

--- a/timestamp.go
+++ b/timestamp.go
@@ -23,8 +23,8 @@ import (
 type FailureInfo int
 
 const (
-	// UnkownFailureInfo mean that no known failure info was provided
-	UnkownFailureInfo FailureInfo = -1
+	// UnknownFailureInfo mean that no known failure info was provided
+	UnknownFailureInfo FailureInfo = -1
 	// BadAlgorithm defines an unrecognized or unsupported Algorithm Identifier
 	BadAlgorithm FailureInfo = 0
 	// BadRequest indicates that the transaction not permitted or supported
@@ -268,7 +268,7 @@ func ParseResponse(bytes []byte) (*Timestamp, error) {
 	if resp.Status.Status > 0 {
 		var fis string
 		fi := resp.Status.FailureInfo()
-		if fi != UnkownFailureInfo {
+		if fi != UnknownFailureInfo {
 			fis = fi.String()
 		}
 		return nil, fmt.Errorf("%s: %s (%v)",
@@ -553,7 +553,7 @@ func (t *Timestamp) populateSigningCertificateV2Ext(certificate *x509.Certificat
 		return nil, x509.ErrUnsupportedAlgorithm
 	}
 	if t.HashAlgorithm.HashFunc() == crypto.SHA1 {
-		return nil, fmt.Errorf("for SHA1 usae ESSCertID instead of ESSCertIDv2")
+		return nil, fmt.Errorf("for SHA1 use ESSCertID instead of ESSCertIDv2")
 	}
 
 	h := t.HashAlgorithm.HashFunc().New()
@@ -596,7 +596,13 @@ func (t *Timestamp) generateSignedData(tstInfo []byte, signer crypto.Signer, cer
 	if err != nil {
 		return nil, err
 	}
-	signedData.SetDigestAlgorithm(pkcs7.OIDDigestAlgorithmSHA256)
+
+	digestAlgOID, err := pkcs7.GetDigestOIDForSignatureAlgorithm(certificate.SignatureAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+
+	signedData.SetDigestAlgorithm(digestAlgOID)
 	signedData.SetContentType(asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 1, 4})
 
 	signingCertV2Bytes, err := t.populateSigningCertificateV2Ext(certificate)
@@ -632,7 +638,7 @@ func (t *Timestamp) generateSignedData(tstInfo []byte, signer crypto.Signer, cer
 	return signature, nil
 }
 
-// copied from cryto/x509 package
+// copied from crypto/x509 package
 // oidNotInExtensions reports whether an extension with the given oid exists in
 // extensions.
 func oidInExtensions(oid asn1.ObjectIdentifier, extensions []pkix.Extension) bool {


### PR DESCRIPTION
Small follow up PR to https://github.com/digitorus/pkcs7/pull/11. This pull request uses `pkcs7.GetDigestOIDForSignatureAlgorithm` to set the digest algorithm used in the signing process. Currently the digest algorithm is hardcoded to SHA-256. This PR also fixes a few small typos.